### PR TITLE
Fix pattern matching

### DIFF
--- a/crates/pion-core/src/elab/match/compile.rs
+++ b/crates/pion-core/src/elab/match/compile.rs
@@ -87,16 +87,9 @@ pub fn compile_match<'core>(
                 let default = match Lit::is_exhaustive(&lits) {
                     true => None,
                     false => {
-                        let name = BinderName::Underscore;
                         let mut matrix = ctx.default_matrix(matrix);
-
-                        let value = ctx.eval_env().eval(&scrut_expr);
-                        ctx.local_env.push_def(name, scrut.r#type.clone(), value);
-                        shift_amount.push();
                         let body = compile_match(ctx, &mut matrix, bodies, shift_amount);
-                        ctx.local_env.pop();
-
-                        Some((name, body))
+                        Some(body)
                     }
                 };
 

--- a/crates/pion-core/src/elab/unify.rs
+++ b/crates/pion-core/src/elab/unify.rs
@@ -327,8 +327,8 @@ impl<'core, 'env> UnifyCtx<'core, 'env> {
                     left_cases = left_cont;
                     right_cases = right_cont;
                 }
-                (SplitCases::Default(_, left_value), SplitCases::Default(_, right_value)) => {
-                    return self.unify_closures(left_value, right_value);
+                (SplitCases::Default(left_value), SplitCases::Default(right_value)) => {
+                    return self.unify(&left_value, &right_value)
                 }
                 (SplitCases::None, SplitCases::None) => return Ok(()),
                 _ => return Err(UnifyError::Mismatch),
@@ -492,8 +492,8 @@ impl<'core, 'env> UnifyCtx<'core, 'env> {
                                     pattern_cases.push((lit, self.rename(meta_var, &expr)?));
                                     cases = next_cases;
                                 }
-                                SplitCases::Default(name, expr) => {
-                                    break Some((name, self.rename_closure(meta_var, &expr)?))
+                                SplitCases::Default(value) => {
+                                    break Some(self.rename(meta_var, &value)?)
                                 }
                                 SplitCases::None => break None,
                             }

--- a/crates/pion-core/src/pretty.rs
+++ b/crates/pion-core/src/pretty.rs
@@ -223,9 +223,9 @@ impl<'pretty> PrettyCtx<'pretty> {
                     let expr = self.blocklike_expr(expr, Prec::MAX);
                     self.lit(*lit).append(" =>").append(expr)
                 });
-                let default = default.as_ref().map(|(name, expr)| {
+                let default = default.as_ref().map(|expr| {
                     let expr = self.blocklike_expr(expr, Prec::MAX);
-                    self.binder_name(*name).append(" =>").append(expr)
+                    self.text("_").append(" =>").append(expr)
                 });
                 let cases = cases.chain(default);
                 let cases = cases.map(|case| self.hardline().append(case).append(","));

--- a/crates/pion-core/src/syntax/iterators.rs
+++ b/crates/pion-core/src/syntax/iterators.rs
@@ -54,7 +54,7 @@ impl<'core> Subexprs<'core> {
             Expr::Match(.., (scrut, default), cases) => {
                 f(scrut)?;
                 cases.iter().try_for_each(|(_, expr)| f(expr))?;
-                if let Some((_, expr)) = default {
+                if let Some(expr) = default {
                     f(expr)?;
                 }
             }

--- a/tests/elab/errors/pattern_matching/duplicate_name.snapshot
+++ b/tests/elab/errors/pattern_matching/duplicate_name.snapshot
@@ -9,24 +9,23 @@ types of expressions:
 span   | source                                   | type
 -------|------------------------------------------|-----------------------------
 8..35 | let(x, y, x) = (1, 2, 3); x              | Int
-23..32 | (1, 2, 3)                                | (Int, Int, Int)
+23..32 | (1, 2, 3)                                | (Int, Int, #error)
 24..25 | 1                                        | Int
 27..28 | 2                                        | Int
-30..31 | 3                                        | Int
+30..31 | 3                                        | #error
 34..35 | x                                        | Int
 types of patterns:
 span   | source                                   | type
 -------|------------------------------------------|-----------------------------
-11..20 | (x, y, x)                                | (?0, ?1, ?2)
+11..20 | (x, y, x)                                | (?0, ?1, #error)
 12..13 | x                                        | ?0
 15..16 | y                                        | ?1
-18..19 | x                                        | ?2
+18..19 | x                                        | #error
 metavars:
 ?0 = Int
 ?1 = Int
-?2 = Int
 
-def g: Int -> Int -> Int -> Int = fun(x: Int, y: Int, x: Int) => y;
+def g: Int -> Int -> Int -> Int = fun(x: Int, y: Int, _: Int) => y;
 types of expressions:
 span   | source                                   | type
 -------|------------------------------------------|-----------------------------

--- a/tests/elab/ok/match/bool.pion
+++ b/tests/elab/ok/match/bool.pion
@@ -7,3 +7,11 @@ def bool-to-int = fun(x) => match x {
     true => 1,
     false => 0,
 };
+
+// regression test: dont bind `z` twice (once as the default branch of the
+// match, then again as a `let` in RHS). This required removing the ability of
+// core `match` exprs to bind variables in their default branch.
+def apply = fun(x: Bool, f: Bool -> Int) => match x {
+    true => 1,
+    z => f(z),
+};

--- a/tests/elab/ok/match/bool.snapshot
+++ b/tests/elab/ok/match/bool.snapshot
@@ -46,6 +46,37 @@ span   | source                                   | type
 metavars:
 ?0 = Bool
 ?1 = fun(_: #error) => Int
+
+def apply: Bool -> (Bool -> Int) -> Int =
+    fun(x: Bool, f: Bool -> Int) => match x {
+        true => 1,
+        _ =>
+            let z: Bool = x;
+            f(z),
+    };
+types of expressions:
+span   | source                                   | type
+-------|------------------------------------------|-----------------------------
+376..449 | fun(x: Bool, f: Bo...\n    z => f(z),\n} | Bool -> (Bool -> Int) -> Int
+383..387 | Bool                                     | Type
+392..396 | Bool                                     | Type
+392..403 | Bool -> Int                              | Type
+400..403 | Int                                      | Type
+408..449 | match x {\n    tru...\n    z => f(z),\n} | Int
+414..415 | x                                        | Bool
+430..431 | 1                                        | Int
+442..443 | f                                        | Bool -> Int
+442..446 | f(z)                                     | Int
+444..445 | z                                        | Bool
+types of patterns:
+span   | source                                   | type
+-------|------------------------------------------|-----------------------------
+380..381 | x                                        | Bool
+389..390 | f                                        | Bool -> Int
+422..426 | true                                     | Bool
+437..438 | z                                        | Bool
+metavars:
+?0 = fun(_: #error, _: #error) => Int
 """
 
 stderr = """


### PR DESCRIPTION
`core::Expr::Match` no longer binds the scrutinee to a variable
    
This means one less place to fiddle with variable binders, and fixes a bug in pattern match elaboration.