### PR TITLE
Use `bpaf` for argument parsing instead of `clap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
+name = "bpaf"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dc3b1bd654a8d16eea03586c3eee8ffd25c7f242b9eae9730cc442834fe56d9"
+
+[[package]]
 name = "bstr"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -810,9 +816,9 @@ name = "pion"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "bpaf",
  "bumpalo",
  "camino",
- "clap",
  "codespan-reporting",
  "pion-core",
  "pion-hir",

--- a/crates/pion/Cargo.toml
+++ b/crates/pion/Cargo.toml
@@ -19,9 +19,9 @@ pion-surface         = { path = "../pion-surface" }
 pion-utils           = { path = "../pion-utils" }
 
 anyhow             = { workspace = true }
+bpaf               = { version = "0.9.5" }
 bumpalo            = { workspace = true }
 camino             = { workspace = true }
-clap               = { version = "4.3.12", features = ["derive"] }
 codespan-reporting = { workspace = true }
 tikv-jemallocator  = { version = "0.5.4" }
 

--- a/crates/pion/src/check.rs
+++ b/crates/pion/src/check.rs
@@ -1,19 +1,23 @@
 use std::io::Write;
 
 use anyhow::bail;
+use bpaf::Parser;
 use camino::Utf8PathBuf;
 use codespan_reporting::diagnostic::{Diagnostic, Severity};
 use pion_utils::source::{SourceFile, SourceMap};
 
 use crate::DumpFlags;
 
-#[derive(Debug, clap::Args)]
+#[derive(Debug, Clone)]
 pub struct CheckArgs {
-    #[arg(required = true)]
     files: Vec<Utf8PathBuf>,
-
-    #[arg(short, long)]
     quiet: bool,
+}
+
+pub fn parse_check_args() -> impl Parser<CheckArgs> {
+    let quiet = bpaf::long("quiet").short('q').switch();
+    let files = bpaf::positional("FILES").some("expected input files");
+    bpaf::construct!(CheckArgs { quiet, files })
 }
 
 fn stop_if_errors(error_count: u32) -> anyhow::Result<()> {

--- a/crates/pion/src/main.rs
+++ b/crates/pion/src/main.rs
@@ -3,14 +3,12 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 
 use std::process::ExitCode;
 
-use clap::Parser;
-use pion::DumpFlags;
+use bpaf::Parser;
 
 fn main() -> ExitCode {
     let result: anyhow::Result<()> = (|| {
-        let args = pion::Cli::try_parse()?;
-
-        let dump_flags = DumpFlags::new(&args.dump);
+        let args = pion::parse_cli().run();
+        let dump_flags = args.dump_flags;
 
         match args.command {
             pion::Command::LanguageServer => pion_language_server::run()?,

--- a/crates/pion/tests/integration_tests.rs
+++ b/crates/pion/tests/integration_tests.rs
@@ -30,7 +30,7 @@ fn elab() {
     fn test(input_path: &Path) -> Result<String, Box<dyn std::error::Error>> {
         let path = input_path.to_str().unwrap();
         let mut command = std::process::Command::new(PION_EXE);
-        command.args(["--dump=core", "check", path]);
+        command.args(["--dump-core", "check", path]);
         let output = command.output()?;
         let exit_status = output.status;
         Ok(format!(


### PR DESCRIPTION
closes #36 